### PR TITLE
Wrong function name makeUrl changed to make

### DIFF
--- a/content/guides/http/routing.md
+++ b/content/guides/http/routing.md
@@ -323,7 +323,7 @@ const url = Route.builder()
   .params({ id: 1 })
   .qs({ verified: true })
   .prefixUrl('https://foo.com')
-  .makeUrl('UsersController.show')
+  .make('UsersController.show')
 ```
 
 Make for a domain


### PR DESCRIPTION
Based on the document, the Url builder says the method is "makeUrl". However, when I look at the contract "UrlBuilderContract", the method name is "url".
I think the documentation needs to change.
Sorry if my understanding is wrong.